### PR TITLE
Do not show author as participant

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func run(all bool, authorFilter string) error {
 			continue
 		}
 
-		author := ms(pr, "author", "login")
+		author := prAuthor(pr)
 		participants := getParticipants(pr, author)
 		mergeableMark := ""
 		destMark := ""
@@ -262,6 +262,7 @@ func getParticipants(pr interface{}, author string) []string {
 }
 
 func lastReviewsPerUser(pr interface{}) map[string]interface{} {
+	prAuthor := prAuthor(pr)
 	reviewers := make(map[string]interface{})
 	for _, review := range l(m(pr, "reviews", "nodes")) {
 		author := ms(review, "author", "login")
@@ -281,7 +282,7 @@ func lastReviewsPerUser(pr interface{}) map[string]interface{} {
 				reviewers[author] = review
 			}
 
-		} else {
+		} else if author != prAuthor {
 			reviewers[author] = review
 		}
 	}
@@ -297,6 +298,10 @@ func filterReviews(reviews map[string]interface{}, status string, symbol string)
 		}
 	}
 	return result
+}
+
+func prAuthor(pr interface{}) string {
+	return ms(pr, "author", "login")
 }
 
 type statusTransform struct {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not show PR author in participants list.  There is already a check for that, but it only applies to comments.  This change applies the same condition to "reviews" from PR author, which can appear eg. due to replies to genuine review comments.

## How was this patch tested?

Built and ran locally.

old:

```
| 835 | >elek         | HDDS-3399. Update JaegerTracing                    | ✓ADORO,ELEK                         | _______ ______ |
| 816 | >bharatviswa5 | HDDS-3381. OzoneManager starts 2 OzoneManagerDoubl | BHARA                               | _______ ______ |
| 794 | >iamabug      | HDDS-2804. tools/TestTools.md                      | XIAOY,IAMAB,adoro                   | _______ ______ |
```

new:

```
| 835 | >elek         | HDDS-3399. Update JaegerTracing                    | ✓ADORO                              | _______ ______ |
| 816 | >bharatviswa5 | HDDS-3381. OzoneManager starts 2 OzoneManagerDoubl |                                     | _______ ______ |
| 794 | >iamabug      | HDDS-2804. tools/TestTools.md                      | XIAOY,adoro                         | _______ ______ |
```