### PR TITLE
use GITHUB_USER for `mine`

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 		},
 		{
 			Name:    "mine",
-			Aliases: []string{"pr"},
+			Aliases: []string{"m"},
 			Usage:   "Show results of the pr from the current user",
 			Flags: []cli.Flag{
 				cli.StringFlag{
@@ -75,14 +75,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				userName := c.String("user")
-				if userName == "" {
-					user, err := user.Current()
-					if err == nil {
-						userName = user.Username
-					}
-				}
-				return run(true, userName)
+				return run(true, getUser(c))
 			},
 		},
 		{
@@ -324,6 +317,23 @@ func filterReviews(reviews map[string]interface{}, status string, symbol string)
 
 func prAuthor(pr interface{}) string {
 	return ms(pr, "author", "login")
+}
+
+func getUser(c *cli.Context) string {
+	userName := c.String("user")
+
+	if userName == "" {
+		userName = os.Getenv("GITHUB_USER")
+	}
+
+	if userName == "" {
+		user, err := user.Current()
+		if err == nil {
+			userName = user.Username
+		}
+	}
+
+	return userName
 }
 
 type statusTransform struct {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When `ogh mine` is called without `--user` argument, use value of `GITHUB_USER` if set (non-empty) before falling back to current OS user.

Change alias of `mine` from `pr` (already taken for `pull-requests`) to `m`.

## How was this patch tested?

```
$ GITHUB_USER='' ogh mine
+----+--------+---------+--------------+-------+
| ID | AUTHOR | SUMMARY | PARTICIPANTS | CHECK |
+----+--------+---------+--------------+-------+
+----+--------+---------+--------------+-------+

$ GITHUB_USER='adoroszlai' ogh mine
+-----+-------------+----------------------------------------------------+--------------------+----------------+
| ID  |   AUTHOR    |                      SUMMARY                       |    PARTICIPANTS    |     CHECK      |
+-----+-------------+----------------------------------------------------+--------------------+----------------+
| 867 | >adoroszlai | HDDS-3373. Intermittent failure in TestOMRatisLogP | ✓ELEK              | _______ ______ |
| 857 | >adoroszlai | [D]HDDS-3385. Simplify S3 -> Ozone volume mapping  | ?BHARA,?ELEK,?ARP7 | _______ ______ |
+-----+-------------+----------------------------------------------------+--------------------+----------------+

$ GITHUB_USER='' ogh mine --user=elek
+-----+--------+----------------------------------------------------+--------------------------------+----------------+
| ID  | AUTHOR |                      SUMMARY                       |          PARTICIPANTS          |     CHECK      |
+-----+--------+----------------------------------------------------+--------------------------------+----------------+
| 578 | >elek  | HDDS-3053. Decrease the number of the chunk writer | ✓ADORO,✓BSHAS,xiaoy,arp7,bhara | _______ ______ |
| 785 | >elek  | HDDS-3234. Fix retry interval default in Ozone cli |                                | ______a ___c__ |
| 745 | >elek  | [C] HDDS-3315. Use EventQueue for delayed/immediat | ✓SODON                         | _______ ______ |
+-----+--------+----------------------------------------------------+--------------------------------+----------------+
```