### PR TITLE
use first arg for repo

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 			Aliases: []string{"r"},
 			Usage:   "Show the review queue (all READY pull requests)",
 			Action: func(c *cli.Context) error {
-				ref := ParseReference(c.Args().Get(1))
+				ref := ParseReference(c.Args().Get(0))
 				return run(false, "", ref)
 			},
 		},
@@ -108,7 +108,7 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				ref := ParseReference(c.Args().Get(1))
+				ref := ParseReference(c.Args().Get(0))
 				return run(true, getUser(c), ref)
 			},
 		},


### PR DESCRIPTION
## What changes were proposed in this pull request?

Take repo from (optional) first argument, not second, for `review` and `mine` commands.

## How was this patch tested?

Previously:

```
$ ogh r incubator-ratis
DBG 'apache-hadoop-ozone-review' is read from the cache
+-----+-----+---------------+----------------------------------------------------+---------------------------------+----------------+
| ID  | UPD |    AUTHOR     |                      SUMMARY                       |          PARTICIPANTS           |     CHECK      |
+-----+-----+---------------+----------------------------------------------------+---------------------------------+----------------+
| 780 | 0h  | >iamabug      | HDDS-2800. tools/_index.md translation             | CXORM,ELEK                      | _______ ______ |
...
```

Now:

```
$ ogh r incubator-ratis
DBG 'apache-incubator-ratis-review' is read from the cache
+----+-----+---------------+----------------------------------------------------+--------------+----------------+
| ID | UPD |    AUTHOR     |                      SUMMARY                       | PARTICIPANTS |     CHECK      |
+----+-----+---------------+----------------------------------------------------+--------------+----------------+
| 60 | 2d  | >esahekmat    | RATIS-846: create simplest possible example, a rep | JNP          | ....... ...... |
...
```