### PR TITLE
add coverage check, support matrix build for integration

### DIFF
--- a/builds.go
+++ b/builds.go
@@ -92,6 +92,13 @@ var transmap = map[string]statusTransform{
 	"it-hdds-om":             statusTransform{12, 'm'},
 	"it-om":                  statusTransform{12, 'm'},
 	"it-ozone":               statusTransform{13, 'o'},
+	"integration (freon)":               statusTransform{8, 'f'},
+	"integration (filesystem)":          statusTransform{9, 's'},
+	"integration (filesystem-contract)": statusTransform{10, 'c'},
+	"integration (client)":              statusTransform{11, 'c'},
+	"integration (hdds-om)":             statusTransform{12, 'm'},
+	"integration (ozone)":               statusTransform{13, 'o'},
+	"coverage":               statusTransform{15, 'c'},
 }
 
 func stepsAsString(jobs []interface{}) string {
@@ -118,7 +125,7 @@ func stepsAsString(jobs []interface{}) string {
 }
 
 func buildStatus(pr interface{}) string {
-	result := []byte("....... ......")
+	result := []byte("....... ...... .")
 
 	for _, commitEdge := range l(m(pr, "commits", "edges")) {
 		commit := m(commitEdge, "node", "commit")


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add recently introduced `coverage` check (apache/hadoop-ozone@67244e551).
2. Support matrix build for `integration` check (https://github.com/apache/hadoop-ozone/pull/1063).

## How was this patch tested?

```
$ go build && ./ogh r
+------+-----+---------------+----------------------------------------------------+-------------------------------------+------------------+
|  ID  | UPD |    AUTHOR     |                      SUMMARY                       |            PARTICIPANTS             |      CHECK       |
+------+-----+---------------+----------------------------------------------------+-------------------------------------+------------------+
| 1074 | 0h  | >adoroszlai   | HDDS-3793. Use Hadoop 2.7.3 for ozone-mr/hadoop27  | codec                               | _______ ______ _ |
| 1063 | 2h  | >adoroszlai   | HDDS-3784. Use matrix build for integration test   | codec,vivek,?ELEK                   | _______ ______ _ |
| 1044 | 5h  | >runzhiwang   | HDDS-3743. Avoid NetUtils#normalize when get Datan | XIAOY,codec                         | _______ ______ _ |
| 1061 | 7h  | >bshashikant  | HDDS-3262. Fix TestOzoneRpcClientWithRatis.java.   | codec,bhara                         | _______ ______ _ |
...
```