### PR TITLE
support artifacts whose name does not match job name

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -12,6 +12,15 @@ import (
 	"strings"
 )
 
+var artifactMap = map[string]string {
+	"integration (freon)":               "it-freon",
+	"integration (filesystem)":          "it-filesystem",
+	"integration (filesystem-contract)": "it-filesystem-contract",
+	"integration (client)":              "it-client",
+	"integration (hdds-om)":             "it-hdds-om",
+	"integration (ozone)":               "it-ozone",
+}
+
 func downloadArtifacts(org string, buildIdExpression string, destinationDir string, all bool) error {
 
 	if strings.HasPrefix(buildIdExpression, "pr/") {
@@ -65,7 +74,11 @@ func downloadArtifactsOfRun(org string, runId string, destinationDir string, all
 		return err
 	}
 	for _, job := range l(m(jobs, "jobs")) {
-		results[ms(job, "name")] = ms(job, "conclusion")
+		name := ms(job, "name")
+		if artifact, ok := artifactMap[name]; ok {
+			name = artifact
+		}
+		results[name] = ms(job, "conclusion")
 	}
 
 	_ = os.RemoveAll(destinationDir)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone matrix-style integration builds are named like `integration (client)`, but their artifacts have the old name (eg. `it-client`) to avoid spaces.  These artifacts are currently ignored by `ogh artifacts` (unless `--all` is used).  This change fixes the problem.

## How was this patch tested?

Tested with [new-style build](https://github.com/apache/hadoop-ozone/actions/runs/136107477):

```
$ ./ogh artifacts #136107477
Downloading results of it-client to /tmp/136107477
Extracting failures to /tmp/136107477/it-client/failures
Extracting jacoco-combined.exec to /tmp/136107477/it-client/jacoco-combined.exec
Extracting output.log to /tmp/136107477/it-client/output.log
Extracting summary.md to /tmp/136107477/it-client/summary.md
Extracting summary.txt to /tmp/136107477/it-client/summary.txt
Extracting org.apache.hadoop.ozone.client.rpc.TestMultiBlockWritesWithDnFailures-output.txt to /tmp/136107477/it-client/hadoop-ozone/integration-test/org.apache.hadoop.ozone.client.rpc.TestMultiBlockWritesWithDnFailures-output.txt
Extracting org.apache.hadoop.ozone.client.rpc.TestMultiBlockWritesWithDnFailures.txt to /tmp/136107477/it-client/hadoop-ozone/integration-test/org.apache.hadoop.ozone.client.rpc.TestMultiBlockWritesWithDnFailures.txt
Extracting TEST-org.apache.hadoop.ozone.client
```

as well as [old-style one](https://github.com/apache/hadoop-ozone/actions/runs/135082814):

```
$ ./ogh artifacts #135082814
Downloading results of unit to /tmp/135082814
Extracting failures to /tmp/135082814/unit/failures
Extracting jacoco-combined.exec to /tmp/135082814/unit/jacoco-combined.exec
Extracting output.log to /tmp/135082814/unit/output.log
Extracting summary.md to /tmp/135082814/unit/summary.md
Extracting summary.txt to /tmp/135082814/unit/summary.txt
Extracting org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainer-output.txt to /tmp/135082814/unit/hadoop-hdds/container-service/org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainer-output.txt
Extracting org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainer.txt to /tmp/135082814/unit/hadoop-hdds/container-service/org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainer.txt
Extracting TEST-org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainer.xml to /tmp/135082814/unit/hadoop-hdds/container-service/TEST-org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainer.xml
```