### PR TITLE
[fix] ignore artifact with unknown result

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 func downloadArtifacts(org string, buildIdExpression string, destinationDir string, all bool) error {
@@ -88,11 +89,10 @@ func downloadArtifactsOfRun(org string, runId string, destinationDir string, all
 		name := ms(artifact, "name")
 		result, found := results[name]
 		if !found {
-			return errors.New("Job result for the artifact " + name + " is unknown")
-		}
-		if all || result == "failure" {
+			log.Debug().Msg("Job result for the artifact " + name + " is unknown")
+		} else if all || result == "failure" {
 
-			println("Downloading results of " + name + " to " + destinationDir)
+			log.Info().Msg("Downloading results of " + name + " to " + destinationDir)
 			err = downloadAndExtract(name, ms(artifact, "archive_download_url"), destinationDir)
 			if err != nil {
 				return err
@@ -142,7 +142,7 @@ func downloadAndExtract(name string, url string, destinationDir string) error {
 				return err
 			}
 		} else {
-			println("Extracting " + f.FileInfo().Name() + " to " + destFile)
+			log.Info().Msg("Extracting " + f.FileInfo().Name() + " to " + destFile)
 			err = os.MkdirAll(path.Dir(destFile), 0755)
 			if err != nil {
 				return err


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `ogh` binary in [elek/ozone-build-results](https://github.com/elek/ozone-build-results) has not archived unit test failures for months.

Example:
https://github.com/apache/ozone/actions/runs/519927292 vs. https://github.com/elek/ozone-build-results/tree/master/2021/01/29/5562

So I thought it was probably time to upgrade `ogh` there.  However, current `master` exits with error due to the recently introduced `ozone-bin` artifact, which is not associated with any jobs:

```
panic: Can't download artifact of the build 5488: Job result for the artifact ozone-bin is unknown
```

This change fixes that by ignoring unknown artifacts.

Also use logger instead of `println`.

## How was this patch tested?

```
INF Download artifacts of build 5562
DBG Job result for the artifact ozone-bin is unknown
INF Downloading results of unit to .../2021/01/29/5562
INF Extracting org.apache.hadoop.ozone.om.ratis.TestOzoneManagerDoubleBufferWithDummyResponse.txt to .../2021/01/29/5562/unit/hadoop-ozone/ozone-manager/org.apache.hadoop.ozone.om.ratis.TestOzoneManagerDoubleBufferWithDummyResponse.txt
```