### PR TITLE
HDDS-5753. Split parts of misc suite

### DIFF
--- a/ozone.go
+++ b/ozone.go
@@ -12,6 +12,8 @@ var artifactMap = map[string]string{
 	"integration (client)":              "it-client",
 	"integration (hdds-om)":             "it-hdds-om",
 	"integration (ozone)":               "it-ozone",
+	"acceptance (HA)":                   "acceptance-HA",
+	"acceptance (MR)":                   "acceptance-MR",
 	"acceptance (misc)":                 "acceptance-misc",
 	"acceptance (secure)":               "acceptance-secure",
 	"acceptance (unsecure)":             "acceptance-unsecure",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some tests were extracted from _acceptance (misc)_ into separate suites: _acceptance (HA)_ and _acceptance (MR)_.  Update `ogh` to download the corresponding artifacts.

https://issues.apache.org/jira/browse/HDDS-5753

## How was this patch tested?

```
$ ./ogh archive /tmp/ozone_builds
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/workflows/8247/runs?per_page=100&branch=master
Download artifacts of build 11602
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/runs/1481018669/artifacts
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/runs/1481018669/jobs
Job result for the artifact ozone-bin is unknown
Download artifacts of build 11579
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/runs/1479027809/artifacts
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/runs/1479027809/jobs
Job result for the artifact ozone-bin is unknown
Download artifacts of build 11570
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/runs/1477655039/artifacts
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/runs/1477655039/jobs
Downloading results of acceptance-MR to /tmp/ozone_builds/2021/11/18/11570
GET url from GITHUB api: https://api.github.com/repos/apache/ozone/actions/artifacts/116090353/zip
Extracting docker-hadoop27-hadoop27-createmrenv-scm.log to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/docker-hadoop27-hadoop27-createmrenv-scm.log
Extracting docker-hadoop31-hadoop31-createmrenv-scm.log to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/docker-hadoop31-hadoop31-createmrenv-scm.log
Extracting docker-hadoop32-hadoop32-createmrenv-scm.log to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/docker-hadoop32-hadoop32-createmrenv-scm.log
Extracting docker-hadoop33-hadoop33-createmrenv-scm.log to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/docker-hadoop33-hadoop33-createmrenv-scm.log
Extracting docker-ozonesecure-mr-ozonesecure-mr-kinit-om.log to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/docker-ozonesecure-mr-ozonesecure-mr-kinit-om.log
Extracting jacoco-combined.exec to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/jacoco-combined.exec
Extracting log.html to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/log.html
Extracting ozone-mr.xml to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/ozone-mr.xml
Extracting ozonesecure-mr.xml to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/ozonesecure-mr.xml
Extracting report.html to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/report.html
Extracting summary.html to /tmp/ozone_builds/2021/11/18/11570/acceptance-MR/summary.html
...
```