### PR TITLE
branch=master filter returns stale results

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -14,7 +14,7 @@ import (
 
 func archiveBuilds(outputDir string) error {
 
-	runs, err := GetWorkflowRunsOfBranch("apache", "hadoop-ozone", "8247", "master")
+	runs, err := GetWorkflowRuns("apache", "hadoop-ozone", "8247")
 	if err != nil {
 		return err
 	}
@@ -23,6 +23,10 @@ func archiveBuilds(outputDir string) error {
 	for _, run := range l(m(runs, "workflow_runs")) {
 
 		if (ms(run,"event") == "pull_request") {
+			continue
+		}
+
+		if (ms(run,"head_branch") != "master") {
 			continue
 		}
 


### PR DESCRIPTION
GitHub returns stale results for the workflow runs query issued by `ogh` (with `branch=master` filter specified).

Periodic update has been finding everything is up-to-date for about a week now.  Latest run is `build 14310`:

```
2022-04-18T18:14:19.0119132Z Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/workflows/8247/runs?per_page=100&branch=master 
2022-04-18T18:14:21.5960982Z Download artifacts of build 14310
...
```

https://github.com/elek/ozone-build-results/runs/6066379743#step:3:7

```
2022-04-12T05:10:47.2554793Z Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/workflows/8247/runs?per_page=100&branch=master 
2022-04-12T05:10:49.1338552Z Download artifacts of build 14310
...
```

https://github.com/elek/ozone-build-results/runs/5984282561#step:3:7

This change moves branch filtering to the client-side.

Tested locally:

```
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/workflows/8247/runs?per_page=100
Download artifacts of build 14481
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/runs/2184911195/artifacts
Reading url from GITHUB api: https://api.github.com/repos/apache/hadoop-ozone/actions/runs/2184911195/jobs
Download artifacts of build 14479
...
```